### PR TITLE
Potential fix for code scanning alert no. 109: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/njsscan-analysis.yml
+++ b/.github/workflows/njsscan-analysis.yml
@@ -2,6 +2,9 @@
 # nodejsscan is a static security code scanner that finds insecure code patterns in your Node.js applications
 
 name: njsscan sarif
+permissions:
+  contents: read
+  security-events: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Theangel256/Caffe/security/code-scanning/109](https://github.com/Theangel256/Caffe/security/code-scanning/109)

To fix this problem, we need to add a `permissions` block at the workflow level (recommended for simplicity), or at the specific job level (`njsscan`). The block should specify the least privileges required: `contents: read` (for reading code), and `security-events: write` (for uploading SARIF scan results by the code scanning action). This should be inserted just after the `name:` declaration at the root of `.github/workflows/njsscan-analysis.yml`. No imports or further definitions are required; it is a simple addition to the YAML file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
